### PR TITLE
fix bug 修复内容

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+### Godot template
+# Godot 4+ specific ignores
+.godot/
+
+# Godot-specific ignores
+.import/
+export.cfg
+export_presets.cfg
+
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores
+.mono/
+data_*/
+mono_crash.*.json
+
+.DS_Store
+

--- a/minesweeper/Minesweeper.gd
+++ b/minesweeper/Minesweeper.gd
@@ -173,7 +173,8 @@ func revealAllMines(avoid : Array[Vector2i]) -> void:
 		for x in range(CELL_ROWS):
 			cellCoords = Vector2i(x, y)
 			if cells[getCellIndex(cellCoords)] == 0:
-				if not avoid.has(cellCoords):
+				# If it was a bomb
+				if not avoid.has(cellCoords) && getAtlasCoords(cellCoords) != Vector2i(1, 0):
 					set_cell(0, cellCoords, 0, Vector2i(2, 0))
 			else:
 				# If it wasn't a bomb and flag is on the cell

--- a/minesweeper/scene.tscn
+++ b/minesweeper/scene.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=5 format=3 uid="uid://bv4345bf1wisa"]
 
 [ext_resource type="Texture2D" uid="uid://mpc1qb2w4tfq" path="res://Tiles.png" id="1_6as8o"]
-[ext_resource type="Script" path="res://Minesweeper.gd" id="2_eounq"]
+[ext_resource type="Script" uid="uid://cmxnww7f4dyk3" path="res://Minesweeper.gd" id="2_eounq"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_4lnry"]
 texture = ExtResource("1_6as8o")


### PR DESCRIPTION
# 问题
扫雷游戏中，如果某个地雷被红旗标记后，当用户踩到地雷后，对于如果红旗标记正确的方格，游戏结束时，预期应该仍然显示红旗样式，但实际显示地雷的样式

# 解决
```GDScript
if cells[getCellIndex(cellCoords)] == 0:
    # If it was a bomb
    if not avoid.has(cellCoords) && getAtlasCoords(cellCoords) != Vector2i(1, 0):
	  set_cell(0, cellCoords, 0, Vector2i(2, 0))
```
其中`&& getAtlasCoords(cellCoords) != Vector2i(1, 0)`为此次新增

# 其他
添加了`.gitignore`文件避免提交额外无用的配置文件